### PR TITLE
Fix typo in style.css header comment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@
   8. Work Experience Style
   9. Education Style
   10. Portfolio Style
-  11. Get in tuch Style
+  11. Get in touch Style
   12. Footer Style
   13. Responsive style
 


### PR DESCRIPTION
## Summary
- correct the typo in the style header comment so it reads "Get in touch Style"

## Testing
- `grep -n "Get in touch" -n css/style.css`

------
https://chatgpt.com/codex/tasks/task_e_68793855254c832ab5bd64a19b28a341