### PR TITLE
Add Jest and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,11 @@ My Portfolio
 * [ ] Redesign using React, Gatsby
 * [ ] Use TailwindCSS or Styled Components for styling
 * [ ] Setup serverless backend?
+
+## Running tests
+
+Install dependencies and run the test suite with:
+
+```bash
+npm test
+```

--- a/js/getExperienceMessage.js
+++ b/js/getExperienceMessage.js
@@ -1,0 +1,7 @@
+function getExperienceMessage(startYear) {
+  const currentYear = new Date().getFullYear();
+  const years = currentYear - startYear;
+  return `${years} year${years !== 1 ? 's' : ''}`;
+}
+
+module.exports = getExperienceMessage;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "davidschoi.com",
+  "version": "1.0.0",
+  "description": "My Portfolio",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/tests/custom.test.js
+++ b/tests/custom.test.js
@@ -1,0 +1,18 @@
+const getExperienceMessage = require('../js/getExperienceMessage');
+
+describe('getExperienceMessage', () => {
+  test('returns "0 years" when startYear is current year', () => {
+    const currentYear = new Date().getFullYear();
+    expect(getExperienceMessage(currentYear)).toBe('0 years');
+  });
+
+  test('returns "1 year" when startYear is last year', () => {
+    const currentYear = new Date().getFullYear();
+    expect(getExperienceMessage(currentYear - 1)).toBe('1 year');
+  });
+
+  test('returns "2 years" when startYear is two years ago', () => {
+    const currentYear = new Date().getFullYear();
+    expect(getExperienceMessage(currentYear - 2)).toBe('2 years');
+  });
+});


### PR DESCRIPTION
## Summary
- initialize package.json with Jest
- expose `getExperienceMessage` for Node usage
- create unit tests for `getExperienceMessage`
- document running tests in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879385ba344832aa1abe6ed08497736