### PR TITLE
Fix CNAME for GitHub Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,2 +1,1 @@
 www.davidschoi.com
-davidschoi.com


### PR DESCRIPTION
## Summary
- keep only one domain entry in `CNAME`

This lets GitHub Pages provision a certificate for the custom domain instead of falling back to the `*.github.com` cert.

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68890e270314832aaabbb70b76a0a015