### PR TITLE
Add jest and DOM tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "type": "commonjs",
   "devDependencies": {
     "jest": "^29.0.0"
+  },
+  "dependencies": {
+    "jest": "^29.0.0"
   }
 }

--- a/tests/indexSections.test.js
+++ b/tests/indexSections.test.js
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+
+let document;
+
+beforeAll(() => {
+  const dom = new JSDOM(html);
+  document = dom.window.document;
+});
+
+describe('index.html main sections', () => {
+  const sections = ['aboutme', 'technical', 'experience', 'education', 'contact', 'footer'];
+  sections.forEach(id => {
+    test(`section with id "${id}" exists`, () => {
+      expect(document.getElementById(id)).not.toBeNull();
+    });
+  });
+});

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+const path = require('path');
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+describe('main.js functionality', () => {
+  let window, document;
+
+  beforeAll(() => {
+    const html = `<!DOCTYPE html><body>
+      <div id="skillsContainer"></div>
+      <section id="technical"></section>
+      <div class="navbar-collapse"></div>
+      <button class="navbar-toggle"></button>
+      <nav class="navbar navbar-inverse navbar-static-top"><a href="#"></a></nav>
+    </body>`;
+    const dom = new JSDOM(html, { url: 'http://localhost/' });
+    window = dom.window;
+    document = window.document;
+
+    global.window = window;
+    global.document = document;
+    global.IntersectionObserver = class {
+      constructor() {}
+      observe() {}
+      disconnect() {}
+    };
+
+    window.getExperienceMessage = require('../js/getExperienceMessage');
+    require('../js/main.js');
+
+    document.dispatchEvent(new window.Event('DOMContentLoaded'));
+  });
+
+  test('skills are rendered into the container', () => {
+    const skills = document.querySelectorAll('#skillsContainer .skillsArea');
+    expect(skills.length).toBe(9);
+    expect(skills[0].querySelector('h4').textContent).toBe('JavaScript');
+  });
+});


### PR DESCRIPTION
## Summary
- add `jest` as a runtime dependency
- create tests to verify HTML sections exist
- test DOM rendering logic from `main.js`

## Testing
- `npm test --silent` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688911967f08832ab30b8ebdf13e3727